### PR TITLE
Constant time comparison to prevent data leaks

### DIFF
--- a/src/main/scala/com/redbubble/hawk/validate/HawkMacValidator.scala
+++ b/src/main/scala/com/redbubble/hawk/validate/HawkMacValidator.scala
@@ -20,5 +20,5 @@ object HawkMacValidator {
   }
 
   private def validateMac(computedMac: MAC, providedMac: MAC): Either[HawkError, MacValid] =
-    (computedMac == providedMac).either(error("Request MAC does not match computed MAC"), MacValid.valid)
+    MAC.isEqual(computedMac, providedMac).either(error("Request MAC does not match computed MAC"), MacValid.valid)
 }

--- a/src/main/scala/com/redbubble/hawk/validate/MAC.scala
+++ b/src/main/scala/com/redbubble/hawk/validate/MAC.scala
@@ -1,5 +1,13 @@
 package com.redbubble.hawk.validate
 
+import java.security.MessageDigest
+
 import com.redbubble.hawk._
 
 final case class MAC(encoded: Base64Encoded)
+
+object MAC {
+  def isEqual(macA: MAC, macB: MAC): Boolean = {
+    MessageDigest.isEqual(macA.encoded.getBytes, macB.encoded.getBytes)
+  }
+}

--- a/src/main/scala/com/redbubble/hawk/validate/Maccer.scala
+++ b/src/main/scala/com/redbubble/hawk/validate/Maccer.scala
@@ -30,7 +30,7 @@ object Maccer {
     context.context.payload.map { payload =>
       context.clientAuthHeader.payloadHash.flatMap { clientProvidedHash =>
         val macFromClientProvidedHash = normalisedHeaderMac(credentials, context, Some(MAC(clientProvidedHash.encoded)))
-        (macFromClientProvidedHash != context.clientAuthHeader.mac).option(errorE("MAC provided in request does not match the computed MAC (payload hash may be invalid)"))
+        (!MAC.isEqual(macFromClientProvidedHash, context.clientAuthHeader.mac)).option(errorE("MAC provided in request does not match the computed MAC (payload hash may be invalid)"))
       }.getOrElse(Right(computePayloadMac(credentials, context, payload)))
     }.getOrElse(errorE("No payload provided for payload validation"))
   }


### PR DESCRIPTION
When comparing the computed mac and the provided mac, the code currently uses the standard == comparison operator. This will exit as soon as it finds differences in a string. This patch updates these calls to use MessageDigest.isEqual on the raw bytes of string, so that given two strings of identical length it will always take the same amount of time to check if they are equal, which prevents early exists from leaking information to attackers.